### PR TITLE
Corrected Separation of Concern Issue in Auth Flow

### DIFF
--- a/airtable/pkce.js
+++ b/airtable/pkce.js
@@ -16,23 +16,13 @@ function generateVerifier() {
     return codeChallenge;
   }
 
-  // Adjust query params for authroize redirect here
-  async function generateAuthURI() {
-    const state = crypto.randomBytes(100).toString('base64url');
+  // Provides a getter for OAuth to fetch a PKCE code challenge
+  async function getPKCECodeChallenge() {
     process.env.PKCE_CODE_VERIFIER = generateVerifier();
     const codeChallenge = await generateCodeChallenge(process.env.PKCE_CODE_VERIFIER);
-    // build the authorization URL
-    const authorizationUrl = new URL(`https://airtable.com/oauth2/v1/authorize`);
-    authorizationUrl.searchParams.set('code_challenge', codeChallenge);
-    authorizationUrl.searchParams.set('code_challenge_method', "S256");
-    authorizationUrl.searchParams.set('state', state);
-    authorizationUrl.searchParams.set('client_id', process.env.AIRTABLE_CLIENT_ID);
-    authorizationUrl.searchParams.set('redirect_uri', `http://localhost:${process.env.PORT || 3000}/oauth/redirect`);
-    authorizationUrl.searchParams.set('response_type', 'code');
-    authorizationUrl.searchParams.set('scope', "data.records:read data.records:write schema.bases:read schema.bases:write webhook:manage");
-    return authorizationUrl.toString();
+    return codeChallenge;
   }
   
 export {
-    generateAuthURI
+    getPKCECodeChallenge
 }


### PR DESCRIPTION
Updated PKCE.js to only handle pkce code challenge generation. 
Moved all auth logic into oauth.js

This pull request refactors the OAuth authorization flow for Airtable by introducing a more modular approach and improving the handling of PKCE code challenges. The most important changes include replacing the `generateAuthURI` function with `getPKCECodeChallenge`, restructuring the authorization URL construction, and enhancing the `startAuthFlow` function for better readability and maintainability.

### Refactoring OAuth Authorization Flow:

* [`airtable/oauth.js`](diffhunk://#diff-8094271693fd48c48312c3cb774df61c88ccd0303b49450dba56944db45eb572L4-R33): Replaced the `generateAuthURI` function with explicit construction of the authorization URL in `startAuthFlow`, adding parameters like `state`, `code_challenge`, and `scope` directly. This improves clarity and modularity in the OAuth flow.
* [`airtable/pkce.js`](diffhunk://#diff-d277f4c7d92bfa58ce5bd7548e5af33468f0fb80792ed94727ea9d16af9168c3L19-R27): Removed the `generateAuthURI` function and introduced `getPKCECodeChallenge` to provide a dedicated getter for generating PKCE code challenges. This simplifies the PKCE handling and removes unnecessary URL construction logic from this file.